### PR TITLE
Changed severity ordering to present most severe

### DIFF
--- a/aws-ecr-continuouscompliance/cft/aws-ecr-continuouscompliance-v1.yaml
+++ b/aws-ecr-continuouscompliance/cft/aws-ecr-continuouscompliance-v1.yaml
@@ -87,6 +87,10 @@ Resources:
               severity = "LOW"
               title = "ECR Finding"
               ECRComplianceRating = 'PASSED'
+              if numMedium:
+                  severity = "MEDIUM"
+                  title = "Medium ECR Vulnerability"
+                  ECRComplianceRating = 'FAILED'
               if numHigh:
                   severity = "HIGH"
                   title = "High ECR Vulnerability"
@@ -95,10 +99,7 @@ Resources:
                   severity = "CRITICAL"
                   title = "Critical ECR Vulnerability"
                   ECRComplianceRating = 'FAILED'
-              if numMedium:
-                  severity = "MEDIUM"
-                  title = "Medium ECR Vulnerability"
-                  ECRComplianceRating = 'FAILED'
+
 
               # ISO Time
               iso8061Time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()


### PR DESCRIPTION
*Issue #, if available:* #3

*Description of changes:* Changed the order so that 'medium' is assigned first and not last - they should be assigned in order of criticality so that the correct level issue is created in SecurityHub


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
